### PR TITLE
Build Error Fix

### DIFF
--- a/yggdrasil-vendor.mk
+++ b/yggdrasil-vendor.mk
@@ -24,6 +24,4 @@ PRODUCT_COPY_FILES += \
     vendor/volla/yggdrasil/proprietary/lib/libshowlogo.so:$(TARGET_COPY_OUT_SYSTEM)/lib/libshowlogo.so \
     vendor/volla/yggdrasil/proprietary/lib/libsysenv_system.so:$(TARGET_COPY_OUT_SYSTEM)/lib/libsysenv_system.so \
     vendor/volla/yggdrasil/proprietary/lib64/libmtk-ril.so:$(TARGET_COPY_OUT_SYSTEM)/lib64/libmtk-ril.so
-    	
-PRODUCT_PACKAGES 
-
+   


### PR DESCRIPTION
[1mvendor/volla/yggdrasil/yggdrasil-vendor.mk:28: [31merror: [0m[1mmissing separator.[0m